### PR TITLE
Created ScoreBoardColors class

### DIFF
--- a/src/main/java/com/forgeessentials/chat/ChatConfig.java
+++ b/src/main/java/com/forgeessentials/chat/ChatConfig.java
@@ -75,7 +75,7 @@ public class ChatConfig extends ConfigLoaderBase
         for (String cmd : config.get("Chat.mute", "mutedCommands", new String[] { "me" }, MUTEDCMD_HELP).getStringList())
             mutedCommands.add(cmd);
 
-        coloredTabMenuEnabled = config.getBoolean(CAT_SB, "Enabled", false, "Whether or not to enable the tab menu");
+        coloredTabMenuEnabled = config.getBoolean(CAT_SB, "Enabled", false, "Whether or not to enable the tab menu colors");
         ModuleChat.instance.setChatLogging(config.get(CATEGORY, "LogChat", true, "Log all chat messages").getBoolean(true));
     }
 

--- a/src/main/java/com/forgeessentials/chat/ChatConfig.java
+++ b/src/main/java/com/forgeessentials/chat/ChatConfig.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.IllegalFormatException;
 import java.util.Set;
 
+import net.minecraft.scoreboard.Scoreboard;
 import net.minecraftforge.common.config.Configuration;
 
 import com.forgeessentials.core.moduleLauncher.config.ConfigLoaderBase;
@@ -42,6 +43,10 @@ public class ChatConfig extends ConfigLoaderBase
 
     public static Set<String> mutedCommands = new HashSet<>();
 
+    public static String CAT_SB = CATEGORY + ".Scoreboard";
+
+    public static boolean coloredTabMenuEnabled;
+
     @Override
     public void load(Configuration config, boolean isReload)
     {
@@ -70,6 +75,7 @@ public class ChatConfig extends ConfigLoaderBase
         for (String cmd : config.get("Chat.mute", "mutedCommands", new String[] { "me" }, MUTEDCMD_HELP).getStringList())
             mutedCommands.add(cmd);
 
+        coloredTabMenuEnabled = config.getBoolean(CAT_SB, "Enabled", false, "Whether or not to enable the tab menu");
         ModuleChat.instance.setChatLogging(config.get(CATEGORY, "LogChat", true, "Log all chat messages").getBoolean(true));
     }
 

--- a/src/main/java/com/forgeessentials/chat/ModuleChat.java
+++ b/src/main/java/com/forgeessentials/chat/ModuleChat.java
@@ -126,6 +126,10 @@ public class ModuleChat
 
         censor = new Censor();
         mailer = new Mailer();
+        if (ChatConfig.coloredTabMenuEnabled)
+        {
+            scoreBoardColors = new ScoreBoardColors();
+        }
 
         setupChatReplacements();
     }
@@ -191,9 +195,10 @@ public class ModuleChat
         APIRegistry.perms.registerPermissionProperty(PERM_TEXTFORMAT, "", "Textformat colors. USE ONLY THE COLOR CHARACTERS AND NO &");
         APIRegistry.perms.registerPermissionProperty(PERM_PLAYERFORMAT, "", "Text to show in front of the player name in chat messages");
         APIRegistry.perms.registerPermissionProperty(PERM_RANGE, "", "Send chat messages only to players in this range of the sender");
+
         if (ChatConfig.coloredTabMenuEnabled)
         {
-            scoreBoardColors = new ScoreBoardColors();
+            scoreBoardColors.registerPerms();
         }
     }
 

--- a/src/main/java/com/forgeessentials/chat/ModuleChat.java
+++ b/src/main/java/com/forgeessentials/chat/ModuleChat.java
@@ -110,6 +110,8 @@ public class ModuleChat
 
     public DiscordHandler discordHandler;
 
+    public ScoreBoardColors scoreBoardColors;
+
     /* ------------------------------------------------------------ */
 
     @SubscribeEvent
@@ -189,6 +191,10 @@ public class ModuleChat
         APIRegistry.perms.registerPermissionProperty(PERM_TEXTFORMAT, "", "Textformat colors. USE ONLY THE COLOR CHARACTERS AND NO &");
         APIRegistry.perms.registerPermissionProperty(PERM_PLAYERFORMAT, "", "Text to show in front of the player name in chat messages");
         APIRegistry.perms.registerPermissionProperty(PERM_RANGE, "", "Send chat messages only to players in this range of the sender");
+        if (ChatConfig.coloredTabMenuEnabled)
+        {
+            scoreBoardColors = new ScoreBoardColors();
+        }
     }
 
     @SubscribeEvent

--- a/src/main/java/com/forgeessentials/chat/ScoreBoardColors.java
+++ b/src/main/java/com/forgeessentials/chat/ScoreBoardColors.java
@@ -37,7 +37,7 @@ public class ScoreBoardColors
 
     public void registerPerms()
     {
-        APIRegistry.perms.registerPermissionProperty(PERM_SCOREBOARD_COLOR, "",
+        APIRegistry.perms.registerPermissionProperty(PERM_SCOREBOARD_COLOR, "f",
                 "Format colors for tab menu/scoreboard. USE ONLY CHARACTERS AND NO &");
     }
 
@@ -70,13 +70,6 @@ public class ScoreBoardColors
         {
             // User has permissions set as part of group
             setPlayerColor(userIdent, APIRegistry.perms.getUserPermissionProperty(userIdent, PERM_SCOREBOARD_COLOR));
-        } else
-        {
-            // User has no color permissions set
-            // For some reason in testing, the username would have the character at the start of their name intepreted
-            // as formatting whenever scoreboard.removePlayerFromTeams was called.
-            // To fix this, we add the player to another team/prefix 'r' after the call, which has no formatting.
-            resetColor(userIdent);
         }
 
     }
@@ -100,21 +93,4 @@ public class ScoreBoardColors
             }
         }
     }
-
-    public void resetColor(UserIdent userIdent)
-    {
-        Scoreboard scoreboard = DimensionManager.getWorld(DimensionType.OVERWORLD.getId()).getScoreboard();
-        if (scoreboard.getTeam("f") == null)
-        {
-            scoreboard.createTeam("f").setPrefix("\u00A7f");
-        }
-        if (scoreboard.getPlayersTeam(userIdent.getUsername()) == null ||
-                !Objects.equals(scoreboard.getPlayersTeam(userIdent.getUsername()).getName(), "f"))
-        {
-            // By the looks of it, white is the default color for the scoreboard text.
-            // If the player is not added to this team, weirdness and lingering values occur in the scoreboard
-            scoreboard.addPlayerToTeam(userIdent.getUsername(), "f");
-        }
-    }
-
 }

--- a/src/main/java/com/forgeessentials/chat/ScoreBoardColors.java
+++ b/src/main/java/com/forgeessentials/chat/ScoreBoardColors.java
@@ -26,6 +26,8 @@ public class ScoreBoardColors
     // From https://stackoverflow.com/a/13667522
     public static final Pattern HEX_PATTERN = Pattern.compile("\\p{XDigit}+");
 
+    private int tickCount = 0;
+    private final int TICK_REFRESH = 40;
 
     public ScoreBoardColors()
     {
@@ -42,13 +44,18 @@ public class ScoreBoardColors
     @SubscribeEvent
     public void tick(TickEvent.ServerTickEvent e)
     {
-        for (EntityPlayerMP playerList : FMLCommonHandler.instance().
-                getMinecraftServerInstance().
-                getPlayerList().getPlayers())
+        if (tickCount % TICK_REFRESH == 0)
         {
-            UserIdent userIdent = UserIdent.get(playerList);
-            updatePlayerColor(userIdent);
+            tickCount = 0;
+            for (EntityPlayerMP playerList : FMLCommonHandler.instance().
+                    getMinecraftServerInstance().
+                    getPlayerList().getPlayers())
+            {
+                UserIdent userIdent = UserIdent.get(playerList);
+                updatePlayerColor(userIdent);
+            }
         }
+        tickCount++;
     }
 
     public void updatePlayerColor(UserIdent userIdent)

--- a/src/main/java/com/forgeessentials/chat/ScoreBoardColors.java
+++ b/src/main/java/com/forgeessentials/chat/ScoreBoardColors.java
@@ -1,0 +1,33 @@
+package com.forgeessentials.chat;
+
+import com.forgeessentials.api.APIRegistry;
+import com.forgeessentials.api.permissions.PermissionEvent.User.ModifyPermission;
+import net.minecraft.scoreboard.Scoreboard;
+import net.minecraft.world.DimensionType;
+import net.minecraftforge.common.DimensionManager;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import java.util.regex.Pattern;
+
+
+public class ScoreBoardColors {
+    public static final String PERM_SCOREBOARD_COLOR = "fe.chat.scoreboardcolor";
+    // From https://stackoverflow.com/a/13667522
+    public static final Pattern HEX_PATTERN = Pattern.compile("\\p{XDigit}+");
+    public void serverStart() {
+        APIRegistry.perms.registerPermissionProperty(PERM_SCOREBOARD_COLOR, "", "Format colors for tab menu/scoreboard. USE ONLY CHARACTERS AND NO &");
+        APIRegistry.FE_EVENTBUS.register(this);
+    }
+    @SubscribeEvent()
+    public void colorChange(ModifyPermission e)
+    {
+        if (e.permissionNode == PERM_SCOREBOARD_COLOR && HEX_PATTERN.matcher(e.value).matches()) {
+            Scoreboard scoreboard = DimensionManager.getWorld(DimensionType.OVERWORLD.getId()).getScoreboard();
+            // Team names are same as color codes, to make things easier to deal with
+            if (scoreboard.getTeam(e.value) == null)
+            {
+                scoreboard.createTeam(e.value).setPrefix(e.value);
+            }
+            scoreboard.addPlayerToTeam(e.ident.getPlayer().getName(), e.value);
+        }
+    }
+}

--- a/src/main/java/com/forgeessentials/chat/ScoreBoardColors.java
+++ b/src/main/java/com/forgeessentials/chat/ScoreBoardColors.java
@@ -1,33 +1,113 @@
 package com.forgeessentials.chat;
 
 import com.forgeessentials.api.APIRegistry;
-import com.forgeessentials.api.permissions.PermissionEvent.User.ModifyPermission;
+import com.forgeessentials.api.UserIdent;
+import com.forgeessentials.api.permissions.PermissionEvent.Group;
+import com.forgeessentials.api.permissions.PermissionEvent.User;
+import com.forgeessentials.util.output.LoggingHandler;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.scoreboard.Scoreboard;
+import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.DimensionType;
 import net.minecraftforge.common.DimensionManager;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
+
+import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
-
-public class ScoreBoardColors {
-    public static final String PERM_SCOREBOARD_COLOR = "fe.chat.scoreboardcolor";
+public class ScoreBoardColors
+{
+    public static final String PERM_SCOREBOARD_COLOR = ModuleChat.PERM + ".scoreboardcolor";
     // From https://stackoverflow.com/a/13667522
     public static final Pattern HEX_PATTERN = Pattern.compile("\\p{XDigit}+");
-    public void serverStart() {
-        APIRegistry.perms.registerPermissionProperty(PERM_SCOREBOARD_COLOR, "", "Format colors for tab menu/scoreboard. USE ONLY CHARACTERS AND NO &");
-        APIRegistry.FE_EVENTBUS.register(this);
-    }
-    @SubscribeEvent()
-    public void colorChange(ModifyPermission e)
+
+
+    public ScoreBoardColors()
     {
-        if (e.permissionNode == PERM_SCOREBOARD_COLOR && HEX_PATTERN.matcher(e.value).matches()) {
-            Scoreboard scoreboard = DimensionManager.getWorld(DimensionType.OVERWORLD.getId()).getScoreboard();
-            // Team names are same as color codes, to make things easier to deal with
-            if (scoreboard.getTeam(e.value) == null)
-            {
-                scoreboard.createTeam(e.value).setPrefix(e.value);
-            }
-            scoreboard.addPlayerToTeam(e.ident.getPlayer().getName(), e.value);
+        APIRegistry.FE_EVENTBUS.register(this);
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    public void registerPerms()
+    {
+        APIRegistry.perms.registerPermissionProperty(PERM_SCOREBOARD_COLOR, "",
+                "Format colors for tab menu/scoreboard. USE ONLY CHARACTERS AND NO &");
+    }
+
+    @SubscribeEvent
+    public void tick(TickEvent.ServerTickEvent e)
+    {
+        for (EntityPlayerMP playerList : FMLCommonHandler.instance().
+                getMinecraftServerInstance().
+                getPlayerList().getPlayers())
+        {
+            UserIdent userIdent = UserIdent.get(playerList);
+            updatePlayerColor(userIdent);
         }
     }
+
+    public void updatePlayerColor(UserIdent userIdent)
+    {
+        if (APIRegistry.perms.getUserPermissionProperty(
+                userIdent, PERM_SCOREBOARD_COLOR) != null)
+        {
+            // User has permissions set individually
+            setPlayerColor(userIdent, APIRegistry.perms.getUserPermissionProperty(userIdent, PERM_SCOREBOARD_COLOR));
+        } else if (APIRegistry.perms.getGroupPermissionProperty(
+                APIRegistry.perms.getPrimaryGroup(userIdent), PERM_SCOREBOARD_COLOR) != null)
+        {
+            // User has permissions set as part of group
+            setPlayerColor(userIdent, APIRegistry.perms.getUserPermissionProperty(userIdent, PERM_SCOREBOARD_COLOR));
+        } else
+        {
+            // User has no color permissions set
+            // For some reason in testing, the username would have the character at the start of their name intepreted
+            // as formatting whenever scoreboard.removePlayerFromTeams was called.
+            // To fix this, we add the player to another team/prefix 'r' after the call, which has no formatting.
+            resetColor(userIdent);
+        }
+
+    }
+
+    public void setPlayerColor(UserIdent userIdent, String colorHex)
+    {
+        if (HEX_PATTERN.matcher(colorHex).matches())
+        {
+            Scoreboard scoreboard = DimensionManager.getWorld(DimensionType.OVERWORLD.getId()).getScoreboard();
+            // Team names are same as color codes, to make things easier to deal with
+            if (scoreboard.getTeam(colorHex) == null)
+            {
+                // Creates team and sets formatting code as prefix
+                scoreboard.createTeam(colorHex).setPrefix("\u00A7" + colorHex);
+            }
+            // If statement in case teams get added instead of set
+            if (scoreboard.getPlayersTeam(userIdent.getUsername()) == null ||
+                    !Objects.equals(scoreboard.getPlayersTeam(userIdent.getUsername()).getName(), colorHex))
+            {
+                scoreboard.addPlayerToTeam(userIdent.getUsername(), colorHex);
+            }
+        }
+    }
+
+    public void resetColor(UserIdent userIdent)
+    {
+        Scoreboard scoreboard = DimensionManager.getWorld(DimensionType.OVERWORLD.getId()).getScoreboard();
+        if (scoreboard.getTeam("f") == null)
+        {
+            scoreboard.createTeam("f").setPrefix("\u00A7f");
+        }
+        if (scoreboard.getPlayersTeam(userIdent.getUsername()) == null ||
+                !Objects.equals(scoreboard.getPlayersTeam(userIdent.getUsername()).getName(), "f"))
+        {
+            // By the looks of it, white is the default color for the scoreboard text.
+            // If the player is not added to this team, weirdness and lingering values occur in the scoreboard
+            scoreboard.addPlayerToTeam(userIdent.getUsername(), "f");
+        }
+    }
+
 }

--- a/src/main/java/com/forgeessentials/permissions/core/ZonedPermissionHelper.java
+++ b/src/main/java/com/forgeessentials/permissions/core/ZonedPermissionHelper.java
@@ -131,6 +131,7 @@ public class ZonedPermissionHelper extends ServerEventHandler implements IPermis
         // permissionDebugFilters.add("fe.economy.cmdprice");
         permissionDebugFilters.add("worldedit.limit.unrestricted");
         permissionDebugFilters.add("fe.worldborder.bypass");
+        permissionDebugFilters.add("fe.chat.scoreboardcolor");
     }
 
     // ------------------------------------------------------------


### PR DESCRIPTION
This needs more testing on a multiplayer server.

This PR adds a ScoreBoardColors class, which is disabled by default. It allows changing the colors of players in the tab list via the permission property fe.chat.scoreboardcolor.